### PR TITLE
Add environment setup section in Korean

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@
 - `prompts/`: Codex 입력 프롬프트 모음
 - `src/`: 애플리케이션 소스 코드
 
+
+## 환경 구축
+DivFlow는 파이썬 표준 라이브러리만 사용하므로 별도의 패키지 설치가 필요하지 않습니다. 가상 환경을 사용하려면 다음 명령을 실행하세요.
+```bash
+python -m venv venv
+source venv/bin/activate  # Windows는 venv\Scripts\activate
+pip install -U pip
+```
 ## 실행 방법
 Python 3.8 이상이 필요합니다. 다음 명령으로 GUI 애플리케이션을 실행할 수 있습니다.
 


### PR DESCRIPTION
## Summary
- update README with environment setup instructions in Korean

## Testing
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_e_684bde0be35483219263de83a34fd37f