### PR TITLE
Update storage path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+data/

--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ Python 3.8 이상이 필요합니다. 다음 명령으로 GUI 애플리케이션
 ```bash
 python -m src
 ```
+
+포트폴리오 데이터는 저장 시 `data/portfolio.json` 파일로 관리됩니다.
+애플리케이션을 처음 실행하면 `data` 폴더가 자동으로 생성됩니다.

--- a/src/storage.py
+++ b/src/storage.py
@@ -7,8 +7,10 @@ from .portfolio import Portfolio
 
 
 class PortfolioStorage:
-    def __init__(self, path: str | Path = "portfolio.json") -> None:
+    def __init__(self, path: str | Path = Path("data") / "portfolio.json") -> None:
         self.path = Path(path)
+        # Ensure the directory for the storage file exists
+        self.path.parent.mkdir(parents=True, exist_ok=True)
 
     def save(self, portfolio: Portfolio) -> None:
         data = [asset.__dict__ for asset in portfolio.assets.values()]


### PR DESCRIPTION
## Summary
- add `.gitignore`
- store portfolio data in `data/portfolio.json`
- document new storage path

## Testing
- `python -m src` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_684be0ab8f2883219a84cba1f682b554