### PR TITLE
Apply comma formatting to currency values

### DIFF
--- a/src/main_window.py
+++ b/src/main_window.py
@@ -108,11 +108,11 @@ class MainWindow(tk.Tk):
                     asset.ticker,
                     f"{asset.weight*100:.1f}%",
                     asset.shares,
-                    f"{asset.avg_cost:.2f}",
-                    f"{price:.2f}",
-                    f"{price*rate:.0f}",
-                    f"{value:.2f}",
-                    f"{value*rate:.0f}",
+                    f"{asset.avg_cost:,.2f}",
+                    f"{price:,.2f}",
+                    f"{price*rate:,.0f}",
+                    f"{value:,.2f}",
+                    f"{value*rate:,.0f}",
                 ),
             )
 


### PR DESCRIPTION
## Summary
- show commas in currency numbers for readability

## Testing
- `python -m src --help` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_684bf6e60b948321b7955ddc3ca98ab8