### PR TITLE
Fix refresh inconsistency after load

### DIFF
--- a/src/fetcher.py
+++ b/src/fetcher.py
@@ -32,3 +32,12 @@ class PriceFetcher:
         if self._exchange_rate is None:
             self._exchange_rate = round(random.uniform(1000, 1500), 2)
         return self._exchange_rate
+
+    def load_cache(
+        self,
+        prices: Dict[str, float],
+        dividends: Dict[str, float],
+    ) -> None:
+        """기존 시세 데이터를 캐시에 미리 로드한다."""
+        self._price_cache.update(prices)
+        self._dividend_cache.update(dividends)

--- a/src/portfolio.py
+++ b/src/portfolio.py
@@ -67,6 +67,10 @@ class PortfolioApp:
         loaded = self.storage.load()
         if loaded:
             self.portfolio = loaded
+            # 기존 저장된 시세 정보를 Fetcher 캐시에 반영한다
+            prices = {t: a.close_price for t, a in loaded.assets.items()}
+            dividends = {t: a.dividend_yield for t, a in loaded.assets.items()}
+            self.price_fetcher.load_cache(prices, dividends)
         if self.ui:
             self.ui.update_ui()
 


### PR DESCRIPTION
## Summary
- keep cached prices when loading saved portfolio
- expose cache loading helper on `PriceFetcher`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c08c1aefc8321a72077dff22d1559