### PR TITLE
Add exchange rate storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ python -m src
 가 발생할 수 있습니다. 반드시 위와 같이 패키지 형태로 실행하세요.
 
 포트폴리오 데이터는 저장 시 `data/portfolio.json` 파일로 관리됩니다.
+환율 정보는 `data/exchange_rate.json` 파일에 별도로 저장됩니다.
 애플리케이션을 처음 실행하면 `data` 폴더가 자동으로 생성됩니다.
 모든 UI 텍스트는 한국어로 제공됩니다.
 시세 조회 기능(`PriceFetcher`)은 Yahoo Finance API를 사용하며 인터넷 연결 실패 시

--- a/doc/README.md
+++ b/doc/README.md
@@ -11,6 +11,6 @@
 - `src/asset.py`: `Asset` 데이터 클래스
 - `src/fetcher.py`: Yahoo Finance에서 가격과 배당을 가져오는 `PriceFetcher`
 - `src/portfolio.py`: 포트폴리오 로직과 `PortfolioApp`
-- `src/storage.py`: 파일 기반 저장소 `PortfolioStorage`
+ - `src/storage.py`: 파일 기반 저장소 `PortfolioStorage` (포트폴리오와 환율 정보를 관리)
 - `src/main_window.py`: GUI 구현 `MainWindow`
 - `src/__main__.py`: 프로그램 진입점

--- a/doc/architecture/development_view.md
+++ b/doc/architecture/development_view.md
@@ -8,7 +8,7 @@
 │   ├── portfolio.py       # PortfolioApp, Portfolio
 │   ├── asset.py           # Asset
 │   ├── fetcher.py         # PriceFetcher
-│   ├── storage.py         # PortfolioStorage
+│   ├── storage.py         # PortfolioStorage (포트폴리오와 환율 저장)
 │   └── main_window.py     # MainWindow
 ```
 

--- a/doc/architecture/diagrams/class_diagram.md
+++ b/doc/architecture/diagrams/class_diagram.md
@@ -40,6 +40,8 @@ classDiagram
     class PortfolioStorage {
         +save(portfolio)
         +load(): Portfolio
+        +save_exchange_rate(rate)
+        +load_exchange_rate(): float
     }
     class MainWindow {
         -tableWidget

--- a/doc/architecture/logical_view.md
+++ b/doc/architecture/logical_view.md
@@ -25,7 +25,7 @@
   - 메서드: fetchClosePrice(), fetchDividend(), fetchAll()
 
 - **PortfolioStorage**  
-  - 메서드: save(), load()
+  - 메서드: save(), load(), save_exchange_rate(), load_exchange_rate()
 
 - **MainWindow**  
   - UI 컴포넌트 및 이벤트 핸들러 (onRefreshClicked, onSaveClicked, onAddFundClicked)

--- a/doc/log/2025-06-13.md
+++ b/doc/log/2025-06-13.md
@@ -5,3 +5,4 @@
 
 - `PriceFetcher`가 Yahoo Finance API를 사용하도록 변경
 - 네트워크 연결 실패 시 원인을 출력하고 0을 반환하도록 변경
+- 환율 정보를 `exchange_rate.json` 파일에 저장/불러오기 기능 추가

--- a/src/portfolio.py
+++ b/src/portfolio.py
@@ -62,6 +62,7 @@ class PortfolioApp:
 
     def save_state(self) -> None:
         self.storage.save(self.portfolio)
+        self.storage.save_exchange_rate(self.exchange_rate)
 
     def load_state(self) -> None:
         loaded = self.storage.load()
@@ -71,6 +72,9 @@ class PortfolioApp:
             prices = {t: a.close_price for t, a in loaded.assets.items()}
             dividends = {t: a.dividend_yield for t, a in loaded.assets.items()}
             self.price_fetcher.load_cache(prices, dividends)
+        rate = self.storage.load_exchange_rate()
+        if rate is not None:
+            self.exchange_rate = rate
         if self.ui:
             self.ui.update_ui()
 

--- a/src/storage.py
+++ b/src/storage.py
@@ -7,15 +7,25 @@ from .portfolio import Portfolio
 
 
 class PortfolioStorage:
-    def __init__(self, path: Union[str, Path] = Path("data") / "portfolio.json") -> None:
+    def __init__(
+        self,
+        path: Union[str, Path] = Path("data") / "portfolio.json",
+        exchange_rate_path: Union[str, Path] = Path("data") / "exchange_rate.json",
+    ) -> None:
         self.path = Path(path)
-        # Ensure the directory for the storage file exists
+        self.exchange_rate_path = Path(exchange_rate_path)
+        # Ensure the directory for the storage files exist
         self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.exchange_rate_path.parent.mkdir(parents=True, exist_ok=True)
 
     def save(self, portfolio: Portfolio) -> None:
         data = [asset.__dict__ for asset in portfolio.assets.values()]
         with self.path.open("w", encoding="utf-8") as fp:
             json.dump(data, fp, ensure_ascii=False, indent=2)
+
+    def save_exchange_rate(self, rate: float) -> None:
+        with self.exchange_rate_path.open("w", encoding="utf-8") as fp:
+            json.dump({"exchange_rate": rate}, fp, ensure_ascii=False, indent=2)
 
     def load(self) -> Optional[Portfolio]:
         if not self.path.exists():
@@ -29,3 +39,17 @@ class PortfolioStorage:
             asset = Asset(**item)
             portfolio.add_asset(asset)
         return portfolio
+
+    def load_exchange_rate(self) -> Optional[float]:
+        if not self.exchange_rate_path.exists():
+            return None
+        with self.exchange_rate_path.open("r", encoding="utf-8") as fp:
+            data = json.load(fp)
+        if isinstance(data, dict):
+            value = data.get("exchange_rate")
+        else:
+            value = data
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None


### PR DESCRIPTION
## Summary
- allow saving/loading exchange rate
- document the new JSON file for the exchange rate

## Testing
- `python -m compileall -q src`
- `python -m src.__main__` *(fails: no display)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c17a9b95c8321998aabf26855510b