### PR TITLE
Add entry point and build script for Windows executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ python -m src
 - 환율과 종가 조회는 1시간 캐시를 사용하여 외부 API 호출을 최소화합니다.
 - 목표 비중뿐 아니라 현재 비중도 테이블에 표시되어 포트폴리오 상황을 즉시 파악할 수 있습니다.
 - 리밸런싱 계산은 남은 입금액을 반복적으로 사용하여 목표 비중에 최대한 맞춰주도록 개선되었습니다.
+
+## Windows 실행 파일 빌드
+Windows 환경에서 단독 실행 가능한 `DivFlow.exe`를 만들려면 아래 명령을 순서대로 실행하세요.
+
+```bash
+pip install pyinstaller
+python build_exe.py
+```
+
+빌드가 끝나면 `dist/DivFlow.exe` 파일이 생성됩니다.

--- a/build_exe.py
+++ b/build_exe.py
@@ -1,0 +1,9 @@
+"""Windows용 실행 파일을 생성하는 빌드 스크립트"""
+import PyInstaller.__main__
+
+if __name__ == "__main__":
+    PyInstaller.__main__.run([
+        "--onefile",
+        "--name", "DivFlow",
+        "main.py",
+    ])

--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+"""DivFlow 앱 실행을 위한 진입점 스크립트"""
+from src.__main__ import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `main.py` entry point for running the app as a script
- include `build_exe.py` to package the project into a Windows `.exe`
- document Windows build steps in README

## Testing
- `python -m py_compile main.py build_exe.py src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa7656fe00832180fd00b930f0efcc